### PR TITLE
Test/sk-03 Fixtures, path aliases and other improvements

### DIFF
--- a/src/pages/ad-posting-page.ts
+++ b/src/pages/ad-posting-page.ts
@@ -8,37 +8,54 @@ export class AdPostingPages {
     constructor(page: Page) {
         this.page = page
         this.postAdButton = this.page.locator('#main-header').getByRole('button')
-        this.alertBanner = page.getByRole('alert', { name: /Importent Notice/})
+        this.alertBanner = page.getByRole('alert', { name: /Importent Notice/ })
     }
 
-    async postAdAndCheckIfTheAlertIsVisible() {
+    async postAdAndCheckIfAlertBannerIsVisible(shouldSeeAlert: boolean) {
         await this.postAdButton.click()
-        await this.adInfoPage()
-        await this.addPhotosPage()
-        await this.visibiltyPage()
-        await this.feedbackPage()
+        await this.adInfoPage(shouldSeeAlert)
+        await this.addPhotosPage(shouldSeeAlert)
+        await this.visibiltyPage(shouldSeeAlert)
+        await this.feedbackPage(shouldSeeAlert)
     }
 
-    private async adInfoPage() {
-        await this.isAlertBannerVisible()
-        // Here code to fill information and move to next page
+    private async adInfoPage(shouldSeeAlert: boolean) {
+        await this.page.waitForLoadState('domcontentloaded')
+        await this.checkAlertVisibility(shouldSeeAlert)
+        // code to fill information require to move to next page
+        // code click on button to next page
     }
 
-    private async addPhotosPage() {
-        await this.isAlertBannerVisible()
+    private async addPhotosPage(shouldSeeAlert: boolean) {
+        await this.page.waitForLoadState('domcontentloaded')
+        await this.checkAlertVisibility(shouldSeeAlert)
         // code to move to next page
     }
 
-    private async visibiltyPage() {
-        await this.isAlertBannerVisible()
+    private async visibiltyPage(shouldSeeAlert: boolean) {
+        await this.page.waitForLoadState('domcontentloaded')
+        await this.checkAlertVisibility(shouldSeeAlert)
         // code to post add
     }
 
-    private async feedbackPage() {
-        await this.isAlertBannerVisible()
+    private async feedbackPage(shouldSeeAlert: boolean) {
+        await this.page.waitForLoadState('domcontentloaded')
+        await this.checkAlertVisibility(shouldSeeAlert, true)
     }
 
-    private async isAlertBannerVisible() {
-        await expect(this.alertBanner).toBeVisible()
+    private async checkAlertVisibility(shouldSeeAlert: boolean, isTheLastPage = false) {
+        if (shouldSeeAlert) {
+            if (isTheLastPage) {
+                await expect(this.alertBanner).toBeVisible({ timeout: 10000 });
+            } else {
+                await expect.soft(this.alertBanner).toBeVisible({ timeout: 10000 });
+            }
+        } else {
+            if (isTheLastPage) {
+                await expect(this.alertBanner).not.toBeVisible({ timeout: 10000 });
+            } else {
+                await expect.soft(this.alertBanner).not.toBeVisible({ timeout: 10000 });
+            }
+        }
     }
 }

--- a/src/pages/ad-posting-page.ts
+++ b/src/pages/ad-posting-page.ts
@@ -43,19 +43,19 @@ export class AdPostingPages {
         await this.checkAlertVisibility(shouldSeeAlert, true)
     }
 
-    private async checkAlertVisibility(shouldSeeAlert: boolean, isTheLastPage = false) {
+    private async checkAlertVisibility(shouldSeeAlert: boolean, isTheLastPage = false, timeout = 10000) {
         if (shouldSeeAlert) {
             if (isTheLastPage) {
-                await expect(this.alertBanner).toBeVisible({ timeout: 10000 });
+                await expect(this.alertBanner).toBeVisible({ timeout })
             } else {
-                await expect.soft(this.alertBanner).toBeVisible({ timeout: 10000 });
+                await expect.soft(this.alertBanner).toBeVisible({ timeout })
             }
         } else {
             if (isTheLastPage) {
-                await expect(this.alertBanner).not.toBeVisible({ timeout: 10000 });
+                await expect(this.alertBanner).not.toBeVisible({ timeout })
             } else {
-                await expect.soft(this.alertBanner).not.toBeVisible({ timeout: 10000 });
-            }
+                await expect.soft(this.alertBanner).not.toBeVisible({ timeout })
+            
         }
     }
 }

--- a/src/pages/modals/age-confirmation.ts
+++ b/src/pages/modals/age-confirmation.ts
@@ -19,4 +19,8 @@ export class AgeConfirmationModal {
             console.warn(`Age verification modal did not appear within 10000 ms: ${error}`);
         }
     }
+
+    async declineAgeVerification() {
+        // code
+    }
 }

--- a/src/pages/modals/cookie-consent.ts
+++ b/src/pages/modals/cookie-consent.ts
@@ -19,4 +19,6 @@ export class CookieConsentModal {
             console.warn(`Cookie consent modal did not appear within 10000 ms: ${error}`);
         }
     }
+
+    // Here code to cover other scenarios 
 }

--- a/src/shared/fixtures.ts
+++ b/src/shared/fixtures.ts
@@ -1,0 +1,30 @@
+import { test as base } from '@playwright/test'
+import { Homepage } from '@pages/homepage'
+import { AgeConfirmationModal } from '@modals/age-confirmation'
+import { CookieConsentModal } from '@modals/cookie-consent'
+import { AdPostingPages } from '@pages/ad-posting-page'
+
+type Fixtures = {
+    homePage: Homepage
+    ageConfirmation: AgeConfirmationModal
+    cookieConsent: CookieConsentModal
+    adPost: AdPostingPages
+}
+
+export const test = base.extend<Fixtures>({
+    homePage: async ({ page, baseURL }, use) => {
+        await page.goto(baseURL)
+        const homePage = new Homepage(page)
+        await use(homePage)
+    },
+
+    ageConfirmation: async ({ page }, use) => {
+        const modal = new AgeConfirmationModal(page)
+        await use(modal)
+    },
+
+    cookieConsent: async ({ page }, use) => {
+        const modal = new CookieConsentModal(page)
+        await use(modal)
+    },
+})

--- a/tests/alert-visiblity.spec.ts
+++ b/tests/alert-visiblity.spec.ts
@@ -1,31 +1,58 @@
-import { test } from '@playwright/test'
-import { Homepage } from '../src/pages/homepage'
-import { AgeConfirmationModal } from '../src/pages/modals/age-confirmation'
-import { CookieConsentModal } from '../src/pages/modals/cookie-consent'
-import { AdPostingPages } from '../src/pages/ad-posting-page'
+import { test } from '@shared/fixtures'
 
-test.describe('Alert Banner during adding ad', () => {
-  let homepage: Homepage
-  let ageConfirmation: AgeConfirmationModal
-  let cookieConsent: CookieConsentModal
-  let adPostingPages: AdPostingPages
-  
-  test.beforeEach(async ({ page }) => {
-    homepage = new Homepage(page)
-    ageConfirmation = new AgeConfirmationModal(page)
-    cookieConsent = new CookieConsentModal(page)
-    adPostingPages = new AdPostingPages(page)
-    await page.goto('/');
-  })
-
-  test('should be visible for user from Argentina', async ({ page }) => {
-    await homepage.selectFirstCityInArgentina()
+test.describe('Alert Banner for non-logged in users', () => {
+  test('should be visible in Argentina during adding ad', async ({ page, homePage, ageConfirmation, cookieConsent, adPost }) => {
+    await homePage.selectFirstCityInArgentina()
 
     await page.waitForLoadState('domcontentloaded')
 
     await ageConfirmation.acceptAgeVerification()
     await cookieConsent.acceptCookieConsent()
 
-    await adPostingPages.postAdAndCheckIfTheAlertIsVisible()
+    await adPost.postAdAndCheckIfAlertBannerIsVisible(true)
+  })
+
+  test('should be visible in Brasil during adding ad', async ({ page, homePage, ageConfirmation, cookieConsent, adPost }) => {
+    await homePage.selectFirstCityInBrasil()
+
+    await page.waitForLoadState('domcontentloaded')
+
+    await ageConfirmation.acceptAgeVerification()
+    await cookieConsent.acceptCookieConsent()
+
+    await adPost.postAdAndCheckIfAlertBannerIsVisible(true)
+  })
+
+  test('should be visible in Singapore during adding ad', async ({ page, homePage, ageConfirmation, cookieConsent, adPost }) => {
+    await homePage.selectFirstCityInSingapore()
+
+    await page.waitForLoadState('domcontentloaded')
+
+    await ageConfirmation.acceptAgeVerification()
+    await cookieConsent.acceptCookieConsent()
+
+    await adPost.postAdAndCheckIfAlertBannerIsVisible(true)
+  })
+
+  test('should be visible in Switzerland during adding ad', async ({ page, homePage, ageConfirmation, cookieConsent, adPost }) => {
+    await homePage.selectFirstCityInSwitzerland()
+
+    await page.waitForLoadState('domcontentloaded')
+
+    await ageConfirmation.acceptAgeVerification()
+    await cookieConsent.acceptCookieConsent()
+
+    await adPost.postAdAndCheckIfAlertBannerIsVisible(true)
+  })
+
+  test('should not be visible in Cyprus during adding ad', async ({ page, homePage, ageConfirmation, cookieConsent, adPost }) => {
+    await homePage.selectFirstCityInCyprus()
+
+    await page.waitForLoadState('domcontentloaded')
+
+    await ageConfirmation.acceptAgeVerification()
+    await cookieConsent.acceptCookieConsent()
+
+    await adPost.postAdAndCheckIfAlertBannerIsVisible(false)
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "resolveJsonModule": true,
+        "esModuleInterop": true,
+        "baseUrl": "./",
+        "paths": {
+            "@pages/*": [
+                "./src/pages/*"
+            ],
+            "@modals/*": [
+                "./src/pages/modals/*"
+            ],
+            "@shared/*": [
+                "./src/shared/*"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This PR enhances the Playwright test suite by adding fixtures, improving assertions and import statements. Key changes include:

- Added path aliases (e.g., @pages, @modals) for cleaner, maintainable imports.
- Improved assertions in AdPostingPages by using expect.soft for intermediate pages and a hard expect on the final feedbackPage.
- Renamed test import to base to prepare for potential fixture extensions.
- Laid groundwork for testing banner visibility across 29 countries (4 with banner, 25 without).